### PR TITLE
Fix uninitialized self.startedTime

### DIFF
--- a/device.js
+++ b/device.js
@@ -104,9 +104,8 @@ Device.prototype.play = function(resource, n, callback){
         }
     }
 
-    if(n){
-      options['currentTime'] = n
-    }
+    options['currentTime'] = n || 0;
+    
     self.player.load(media, options, function(err, status) {
         self.playing = true;
         self.timePosition = options['currentTime'];


### PR DESCRIPTION
When playing from position 0 both options.currentTime and self.startedTime do not get a proper value (because if (0) never happens). This breaks seek, for example.
This commit ensures that does not happen.