### PR TITLE
Fixing `deviceOn` firing too early

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ Browser.prototype.init = function( options ) {
   mdnsBrowser.on('update', function (device) {
       var dev_config = {addresses: device.addresses, name: device.name};
       self.device = new Device(dev_config);
-      self.emit('deviceOn', self.device);
+      self.device.on('connected', function(){
+        self.emit('deviceOn', self.device);
+      });
   });
 };


### PR DESCRIPTION
deviceOn is being called too prematurely. This waits for the device to be really connected to emit the signal.
