### PR TITLE
update to recent package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "chromecast-js",
-  "version": "0.1.5",
-  "description": "Chromecast/Googlecast streaming module all in JS",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/guerrerocarlos/chromecast-js.git"
-  },
-  "keywords": [
-    "chromecast",
-    "googlecast",
-    "stream",
-    "streaming",
-    "torrentv"
-  ],
-  "author": {
-    "name": "Carlos Guerrero",
-    "email": "guerrerocarlos@gmail.com"
-  },
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/guerrerocarlos/chromecast-js/issues"
-  },
-  "homepage": "https://github.com/guerrerocarlos/chromecast-js",
-  "dependencies": {
-    "castv2-client": "0.0.8",
-    "debug": "^1.0.4",
-    "node-ssdp": "^2.0.1"
-  }
+    "author": {
+        "email": "guerrerocarlos@gmail.com", 
+        "name": "Carlos Guerrero"
+    }, 
+    "bugs": {
+        "url": "https://github.com/guerrerocarlos/chromecast-js/issues"
+    }, 
+    "dependencies": {
+        "castv2-client": "~1.1.0", 
+        "debug": "~2.1.3", 
+        "node-ssdp": "~2.1.0"
+    }, 
+    "description": "Chromecast/Googlecast streaming module all in JS", 
+    "homepage": "https://github.com/guerrerocarlos/chromecast-js", 
+    "keywords": [
+        "chromecast", 
+        "googlecast", 
+        "stream", 
+        "streaming", 
+        "torrentv"
+    ], 
+    "license": "ISC", 
+    "main": "index.js", 
+    "name": "chromecast-js", 
+    "repository": {
+        "type": "git", 
+        "url": "https://github.com/guerrerocarlos/chromecast-js.git"
+    }, 
+    "version": "0.1.5"
 }


### PR DESCRIPTION
The packages include are very far behind the current version. In particular, the old version of chromev2-client is very crash prone.  I've updated them - my updating program reorders the package.json. If this isn't OK, the version numbers should still be good.